### PR TITLE
installer: move to a vaguely plan-based workflow

### DIFF
--- a/installer/Cargo.toml
+++ b/installer/Cargo.toml
@@ -13,6 +13,6 @@ lazy_static = "1.4.0"
 libc = "0.2.98"
 log = "0.4.14"
 # generator = { path = "../generator" }
-pico-args = { version = "0.4.2", default-features = false, features = ["eq-separator"] }
+pico-args = { version = "0.4.2", default-features = false, features = ["eq-separator", "combined-flags"] }
 regex = { version = "1.5.4", default-features = false, features = ["std", "unicode"] }
 # askama = "0.10.5"

--- a/installer/src/main.rs
+++ b/installer/src/main.rs
@@ -35,7 +35,7 @@ struct Args {
     install: bool,
 
     // EFI-specific arguments
-    /// The path to the EFI System Partition
+    /// The path to the EFI System Partition(s)
     esp: Vec<PathBuf>,
     /// Whether or not to touch EFI vars in the NVRAM
     can_touch_efi_vars: bool,

--- a/installer/src/systemd_boot/version/systemd.rs
+++ b/installer/src/systemd_boot/version/systemd.rs
@@ -9,7 +9,7 @@ use regex::Regex;
 use super::systemd_boot::SystemdBootVersion;
 use crate::Result;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub struct SystemdVersion {
     pub version: usize,
 }


### PR DESCRIPTION
This basically allows us to (more easily) implement dry run functionality: just print out the debug-formatted `Vec<State>`s.

---

Closes #3.