### PR TITLE
Relocate the expected bootspec document location to be under bootspec/

### DIFF
--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -24,7 +24,7 @@ lazy_static::lazy_static! {
 }
 
 pub fn get_json(generation_path: PathBuf) -> Result<BootJson> {
-    let json_path = generation_path.join(JSON_FILENAME);
+    let json_path = generation_path.join("bootspec").join(JSON_FILENAME);
 
     let mut json: Option<BootJson> = None;
     if json_path.exists() {


### PR DESCRIPTION
##### Description

Implement https://github.com/NixOS/rfcs/pull/125#discussion_r876244736

##### Checklist

<!---
Use `nix-shell` for a shell with all the required dependencies for building /
formatting / testing / etc.
--->

- [ ] Built with `cargo build`
- [ ] Formatted with `cargo fmt`
- [ ] Linted with `cargo clippy`
- [ ] Ran tests with `cargo test`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
