### PR TITLE
generator: drop synthesize dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,6 @@ dependencies = [
  "regex",
  "serde_json",
  "structopt",
- "synthesize",
  "tempfile",
 ]
 
@@ -450,17 +449,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
-]
-
-[[package]]
-name = "synthesize"
-version = "0.1.0"
-source = "git+https://github.com/DeterminateSystems/bootspec?branch=main#308253d2d1057ae217eabdaa3af269010435edce"
-dependencies = [
- "bootspec",
- "clap 3.1.18",
- "serde_json",
- "tempfile",
 ]
 
 [[package]]

--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -20,4 +20,3 @@ serde_json = "1.0.81"
 tempfile = "3.3.0"
 structopt = { version = "0.3.26", default-features = false }
 bootspec = { git = "https://github.com/DeterminateSystems/bootspec", branch = "main" }
-synthesize = { git = "https://github.com/DeterminateSystems/bootspec", branch = "main" }


### PR DESCRIPTION
synthesize is now a binary, and `bootspec` provides the synthesis
functionality itself.

Also fixes:

```
warning: generator v0.1.0 (/home/vin/workspace/detsys/bootloader-experimentation/generator) ignoring invalid dependency  `synthesize` which is missing a lib target
```

##### Description

<!---
Please include a short description of what your PR does and / or the motivation
behind it
--->

##### Checklist

<!---
Use `nix-shell` for a shell with all the required dependencies for building /
formatting / testing / etc.
--->

- [x] Built with `cargo build`
- [x] Formatted with `cargo fmt`
- [x] Linted with `cargo clippy`
- [x] Ran tests with `cargo test`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
