### PR TITLE
dependabot: don't bump bootspec git dependency automatically

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      # Bumping bootspec requires manual intervention to update its hash,
+      # so we don't want to automate it.
+      - dependency-name: "bootspec"


### PR DESCRIPTION
##### Description

See: the failing CI in https://github.com/DeterminateSystems/bootspec-secureboot/pull/156. If it requires manual intervention every time, it might as well require manual submission as well.

##### Checklist

<!---
Use `nix-shell` for a shell with all the required dependencies for building /
formatting / testing / etc.
--->

- [ ] Built with `cargo build`
- [ ] Formatted with `cargo fmt`
- [ ] Linted with `cargo clippy`
- [ ] Ran tests with `cargo test`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
