### PR TITLE
Respect NIXOS_INSTALL_BOOTLOADER

### DIFF
--- a/nixos-module.nix
+++ b/nixos-module.nix
@@ -92,6 +92,7 @@ in
 
             ${pkgs.bootspec-secureboot}/bin/installer \
               --toplevel="$1" \
+              $([ ! -z ''${NIXOS_INSTALL_BOOTLOADER+x} ] && echo --install) \
               ${installerArgs}
           ''
         );


### PR DESCRIPTION
##### Description

While [getting secure boot to work in qemu-vm.nix](https://github.com/NixOS/nixpkgs/commit/ecc9313ec8416a8c900a8ca93e7d2d580778357d), I discovered that systemd-boot is not installed, as `NIXOS_INSTALL_BOOTLOADER` indicates it should be.