### PR TITLE
Replacing objcopy with systemd-ukify.

### DIFF
--- a/generator/src/bootable/efi.rs
+++ b/generator/src/bootable/efi.rs
@@ -27,17 +27,14 @@ impl EfiProgram {
             self.source.kernel_params.join(" ")
         )?;
 
-        println!("**--linux={}/kernel", generation_path.display());
-        println!("**--initrd={}/initrd", generation_path.display());
-        println!("**--cmdline=@{}", kernel_params.path().display());
-        println!("**--os-release=@{}/etc/os-release", generation_path.display());
-
         let status = Command::new(ukify)
             .args(&[
+                "build",
                 &format!("--linux={}/kernel", generation_path.display()),
                 &format!("--initrd={}/initrd", generation_path.display()),
                 &format!("--cmdline=@{}", kernel_params.path().display()),
                 &format!("--os-release=@{}/etc/os-release", generation_path.display()),
+                &format!("--output={}", outpath.display().to_string()),
             ])
             .status()?;
 

--- a/generator/src/bootable/efi.rs
+++ b/generator/src/bootable/efi.rs
@@ -27,8 +27,11 @@ impl EfiProgram {
             self.source.kernel_params.join(" ")
         )?;
 
-        // Offsets taken from one of systemd's EFI tests:
-        // https://github.com/systemd/systemd/blob/01d0123f044d6c090b6ac2f6d304de2bdb19ae3b/test/test-efi-create-disk.sh#L32-L38
+        println!("**--linux={}/kernel", generation_path.display());
+        println!("**--initrd={}/initrd", generation_path.display());
+        println!("**--cmdline=@{}", kernel_params.path().display());
+        println!("**--os-release=@{}/etc/os-release", generation_path.display());
+
         let status = Command::new(ukify)
             .args(&[
                 &format!("--linux={}/kernel", generation_path.display()),

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -8,13 +8,13 @@ use structopt::StructOpt;
 struct Args {
     // TODO: --out-dir?
     /// The systemd-boot EFI stub used to create a unified EFI file
-    #[structopt(long, requires_all = &["objcopy", "unified-efi"])]
+    #[structopt(long, requires_all = &["ukify", "unified-efi"])]
     systemd_efi_stub: Option<PathBuf>,
-    /// The `objcopy` binary
+    /// The `ukify` binary
     #[structopt(long, requires_all = &["systemd-efi-stub", "unified-efi"])]
-    objcopy: Option<PathBuf>,
+    ukify: Option<PathBuf>,
     /// Whether or not to combine the initrd and kernel into a unified EFI file
-    #[structopt(long, requires_all = &["systemd-efi-stub", "objcopy"])]
+    #[structopt(long, requires_all = &["systemd-efi-stub", "ukify"])]
     unified_efi: bool,
     /// The `systemd-machine-id-setup` binary
     // TODO: maybe just pass in machine_id as an arg; if empty, omit from configuration?
@@ -60,7 +60,7 @@ fn main() -> Result<()> {
 
     systemd_boot::generate(
         bootables,
-        args.objcopy,
+        args.ukify,
         args.systemd_efi_stub,
         args.systemd_machine_id_setup,
     )?;

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -61,12 +61,10 @@ fn main() -> Result<()> {
     systemd_boot::generate(
         bootables,
         args.ukify,
+        //In fact systemd_efi_stub is no longer needed here.
         args.systemd_efi_stub,
         args.systemd_machine_id_setup,
     )?;
-
-    // TODO: grub
-    // grub::generate(bootables, args.objcopy)?;
 
     Ok(())
 }

--- a/generator/src/systemd_boot/mod.rs
+++ b/generator/src/systemd_boot/mod.rs
@@ -37,7 +37,7 @@ pub struct Contents {
 
 pub fn generate(
     bootables: Vec<Bootable>,
-    objcopy: Option<PathBuf>,
+    ukify: Option<PathBuf>,
     systemd_efi_stub: Option<PathBuf>,
     systemd_machine_id_setup: PathBuf,
 ) -> Result<()> {
@@ -55,10 +55,10 @@ pub fn generate(
                 write!(f, "{}", contents.conf)?;
 
                 let unified_dest = contents.unified_dest.unwrap();
-                let objcopy = objcopy.as_ref().unwrap();
+                let ukify = ukify.as_ref().unwrap();
                 let systemd_efi_stub = systemd_efi_stub.as_ref().unwrap();
 
-                efi.write_unified_efi(objcopy, Path::new(&unified_dest), systemd_efi_stub)?;
+                efi.write_unified_efi(ukify, Path::new(&unified_dest), systemd_efi_stub)?;
             }
             Bootable::Linux(toplevel) => {
                 let (path, contents) = self::linux_entry_impl(&toplevel, &machine_id)?;

--- a/nixos-module.nix
+++ b/nixos-module.nix
@@ -77,6 +77,8 @@ in
               ]));
           in
           ''
+            mkdir -p /usr/lib/
+            mount --bind ${config.systemd.package}/lib /usr/lib
             set -eux
 
             scratch=$(mktemp -d -t tmp.XXXXXXXXXX)
@@ -94,6 +96,8 @@ in
               --toplevel="$1" \
               $([ ! -z ''${NIXOS_INSTALL_BOOTLOADER+x} ] && echo --install) \
               ${installerArgs}
+
+            umount /usr/lib
           ''
         );
     };

--- a/nixos-module.nix
+++ b/nixos-module.nix
@@ -29,8 +29,8 @@ in
             ++ (lib.optionals config.boot.loader.secureboot.enable [
               "--unified-efi"
 
-              "--objcopy"
-              "${pkgs.binutils-unwrapped}/bin/objcopy"
+              "--ukify"
+              "${config.systemd.package.override { withUkify = true; }}/lib/systemd/ukify"
 
               "--systemd-efi-stub"
               "${config.systemd.package}/lib/systemd/boot/efi/linuxx64.efi.stub"


### PR DESCRIPTION
##### Description

This is a solution for the issue DeterminateSystems/bootspec-secureboot#250. With this fix, secureboot should be running flawlessly with newer versions of systemd-stub. Checked on my computer with nixpkgs rev d008423e161a3714559b1e972153c73ee52eef00.

##### Checklist


- [x] Built with `cargo build`
- [x] Formatted with `cargo fmt`
- [x] Linted with `cargo clippy`
- [x] Ran tests with `cargo test`
- [x] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
